### PR TITLE
Change UrlValidator to org.apache.commons.validator.routines.UrlValid…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add the following to your _grails-app/conf/BuildConfig.groovy_
 	…
 	plugins {
 	…
-		 compile ':url-without-scheme-validator:0.2'
+		 compile ':url-without-scheme-validator:0.3'
 	…
 	}
 
@@ -99,5 +99,7 @@ So the message.properties entry for the class above could look like:
 	com.example.Domain.url.not.urlWithoutScheme={2} is not a valid URL
 
 And result in error message saying for example:
+<pre>
+     <s>www.google</s>www.invalidtld is not a valid URL (.google is valid since version 0.3 (like .beer, .vodka and .pizza)
+<pre>
 
-	www.google is not a valid URL

--- a/UrlWithoutSchemeValidatorGrailsPlugin.groovy
+++ b/UrlWithoutSchemeValidatorGrailsPlugin.groovy
@@ -3,7 +3,7 @@ import org.codehaus.groovy.grails.validation.ConstrainedProperty
 
 class UrlWithoutSchemeValidatorGrailsPlugin {
 	// the plugin version
-	def version = "0.2"
+	def version = "0.3"
 	// the version or versions of Grails the plugin is designed for
 	def grailsVersion = "2.0 > *"
 	// resources that are excluded from plugin packaging

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
-#Sun Apr 20 14:59:17 CEST 2014
-app.grails.version=2.3.7
+#Wed Jun 07 14:51:30 CEST 2017
+app.grails.version=2.5.6
 app.name=UrlWithoutSchemeValidator

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -37,6 +37,15 @@ grails.project.dependency.resolution = {
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
         // runtime 'mysql:mysql-connector-java:5.1.27'
+
+        //update commons-validator version which supports new TLD's (.swiss, ...)
+        compile( "commons-validator:commons-validator:1.6" ) {
+            exclude group: 'xml-apis', module:'xml-apis'
+            exclude group: 'commons-digester', module:'commons-digester'
+            exclude group: 'commons-logging', module:'commons-logging'
+            exclude group: 'commons-beanutils', module:'commons-beanutils'
+            exclude group: 'commons-collections', module:'commons-collections'
+        }
     }
 
     plugins {

--- a/src/groovy/grails/plugin/urlWithoutSchemeValidator/utils/UrlValidatorUtils.groovy
+++ b/src/groovy/grails/plugin/urlWithoutSchemeValidator/utils/UrlValidatorUtils.groovy
@@ -1,6 +1,6 @@
 package grails.plugin.urlWithoutSchemeValidator.utils
 
-import org.codehaus.groovy.grails.validation.routines.UrlValidator
+import org.apache.commons.validator.routines.UrlValidator
 
 import static grails.plugin.urlWithoutSchemeValidator.utils.UrlScheme.*
 

--- a/test/unit/grails/plugin/urlWithoutSchemeValidator/DomainWithValidationSpec.groovy
+++ b/test/unit/grails/plugin/urlWithoutSchemeValidator/DomainWithValidationSpec.groovy
@@ -16,7 +16,7 @@ class DomainWithValidationSpec extends Specification {
 
 	void "should consider invalid domain invalid"() {
 		given:
-		DomainWithValidation domain = new DomainWithValidation(url: 'www.google')
+		DomainWithValidation domain = new DomainWithValidation(url: 'www.google.notexistingtld')
 
 		expect:
 		!domain.validate()
@@ -57,6 +57,14 @@ class DomainWithValidationSpec extends Specification {
 		domain.url == 'http://www.google.com'
 		domain.httpUrl == 'http://www.google.com'
 		domain.ftpUrl == 'http://www.google.com'
+	}
+
+	void "should validate .swiss domain as valid"() {
+		given:
+		DomainWithValidation domain = new DomainWithValidation(url: 'http://dot.swiss')
+
+		expect:
+		domain.validate()
 	}
 
 }

--- a/test/unit/grails/plugin/urlWithoutSchemeValidator/utils/UrlValidatorUtilsSpec.groovy
+++ b/test/unit/grails/plugin/urlWithoutSchemeValidator/utils/UrlValidatorUtilsSpec.groovy
@@ -33,9 +33,33 @@ class UrlValidatorUtilsSpec extends Specification {
 		UrlValidatorUtils.isValid('www.google.com')
 	}
 
+	void "should consider url with new tld valid"() {
+		expect:
+		UrlValidatorUtils.isValid(url)
+
+		where:
+		url                  | _
+		'http://dot.academy' | _
+		'http://dot.abc'     | _
+		'http://dot.beer'    | _
+		'http://dot.glass'   | _
+		'http://dot.pizza'   | _
+		'http://dot.swiss'   | _
+		'http://dot.vodka'   | _
+		'http://dot.wtf'     | _
+		'http://dot.xyz'     | _
+
+	}
+
 	void "should consider invalid url with scheme invalid"() {
 		expect:
-		!UrlValidatorUtils.isValid('http://www.google')
+		!UrlValidatorUtils.isValid(url)
+
+		where:
+		url                         | _
+		'http://dot.notexistingtld' | _
+		'http://dot.ccom'           | _
+
 	}
 
 	void "should consider null invalid"() {


### PR DESCRIPTION
Change UrlValidator to org.apache.commons.validator.routines.UrlValidator
Update/override commons-validator version which supports new TLD's (.swiss, .beer, ...)